### PR TITLE
fix: aio report not setting the issue label

### DIFF
--- a/src/commands/report.js
+++ b/src/commands/report.js
@@ -47,7 +47,7 @@ class ReportCommand extends Command {
     const baseReportUrl = `${bugsUrl}/new/`
     let url
     if (flags.feature) {
-      url = `${baseReportUrl}?body=&title=new+feature+request&label=enhancement`
+      url = `${baseReportUrl}?body=&title=new+feature+request&labels=enhancement`
     } else {
       const resInfo = await envinfo.run({
         System: ['OS', 'CPU', 'Memory', 'Shell'],
@@ -58,7 +58,7 @@ class ReportCommand extends Command {
         json: false, console: false, showNotFound: true
       })
       const issueBody = issueTemplate.replace('%replaced%', resInfo)
-      url = `${baseReportUrl}?body=${encodeURIComponent(issueBody)}&title=new+bug+report&label=bug`
+      url = `${baseReportUrl}?body=${encodeURIComponent(issueBody)}&title=new+bug+report&labels=bug`
     }
     cli.open(url)
   }


### PR DESCRIPTION
## Description

`aio report -f` and `aio report -b` are not setting the Github issue label (if you have permission to do so in the repo). 

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
