### PR TITLE
fix: add proxy scheme mismatch error report

### DIFF
--- a/src/commands/info.js
+++ b/src/commands/info.js
@@ -28,7 +28,17 @@ class InfoCommand extends Command {
 
   printProxy ([key, value], count = 4, indent = ' ') {
     const url = value || '(not set)'
-    this.log(this.indentString(`${key}: ${chalk.gray(url)}`, count, indent))
+    let error = ''
+    if (value && !this.proxyIsValid(key, value)) {
+      error = chalk.red(' (scheme mismatch)')
+    }
+
+    this.log(this.indentString(`${key}: ${chalk.gray(url)}${error}`, count, indent))
+  }
+
+  // check proxy (scheme mismatch)
+  proxyIsValid (key, value) {
+    return value.trim().startsWith(`${key}://`)
   }
 
   async run () {


### PR DESCRIPTION
## Description

Sometimes HTTP_PROXY and HTTPS_PROXY are inaccurately set, where the schemes don't match. This flags the values having a scheme mismatch.

## How Has This Been Tested?

npm test

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
