### PR TITLE
oclif readme --no-aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ DESCRIPTION
   Display dev environment version information
 ```
 
-_See code: [src/commands/info.ts](https://github.com/adobe/aio-cli-plugin-info/blob/3.0.0/src/commands/info.ts)_
+_See code: [src/commands/info.js](https://github.com/adobe/aio-cli-plugin-info/blob/3.0.0/src/commands/info.js)_
 
 ## `aio report`
 
@@ -76,7 +76,7 @@ DESCRIPTION
   Report an issue with the CLI or submit a feature request
 ```
 
-_See code: [src/commands/report.ts](https://github.com/adobe/aio-cli-plugin-info/blob/3.0.0/src/commands/report.ts)_
+_See code: [src/commands/report.js](https://github.com/adobe/aio-cli-plugin-info/blob/3.0.0/src/commands/report.js)_
 <!-- commandsstop -->
 
 ## Contributing

--- a/bin/run
+++ b/bin/run
@@ -11,5 +11,8 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-require('@oclif/command').run()
-.catch(require('@oclif/errors/handle'))
+const oclif = require('@oclif/core')
+
+oclif.run()
+  .then(require('@oclif/core/flush'))
+  .catch(require('@oclif/core/handle'))

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "jest-resolve": "^27.5.1",
     "stdout-stderr": "^0.1.13",
     "typescript": "^4.6.2",
-    "oclif": "^3.0.1"
+    "oclif": "^3.2.0"
   },
   "engines": {
     "node": "^14.18 || ^16.13 || >=18"
@@ -55,7 +55,7 @@
   "scripts": {
     "lint": "eslint src test e2e",
     "test": "jest --ci && npm run lint",
-    "prepack": "oclif manifest && oclif readme",
+    "prepack": "oclif manifest && oclif readme --no-aliases",
     "postpack": "rm -f oclif.manifest.json",
     "version": "oclif readme && git add README.md",
     "e2e": "jest --collectCoverage=false --testRegex './e2e/e2e.js'"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "jest-junit": "^13.0.0",
     "jest-resolve": "^27.5.1",
     "stdout-stderr": "^0.1.13",
-    "typescript": "^4.6.2",
     "oclif": "^3.2.0"
   },
   "engines": {
@@ -49,6 +48,7 @@
   "oclif": {
     "commands": "./src/commands",
     "bin": "aio",
+    "topicSeparator": " ",
     "repositoryPrefix": "<%- repo %>/blob/<%- version %>/<%- commandPath %>"
   },
   "main": "src/index.js",


### PR DESCRIPTION
The new oclif README doc generator was listing the aliases as well as commands (which just clutters up the README docs), now there is a new flag --no-aliases.