### PR TITLE
fix: ACNA-2803 - code links in README point to a .ts file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ DESCRIPTION
   Display dev environment version information
 ```
 
-_See code: [src/commands/info.ts](https://github.com/adobe/aio-cli-plugin-info/blob/4.0.0/src/commands/info.ts)_
+_See code: [src/commands/info.js](https://github.com/adobe/aio-cli-plugin-info/blob/4.0.0/src/commands/info.js)_
 
 ## `aio report`
 
@@ -76,7 +76,7 @@ DESCRIPTION
   Report an issue with the CLI or submit a feature request
 ```
 
-_See code: [src/commands/report.ts](https://github.com/adobe/aio-cli-plugin-info/blob/4.0.0/src/commands/report.ts)_
+_See code: [src/commands/report.js](https://github.com/adobe/aio-cli-plugin-info/blob/4.0.0/src/commands/report.js)_
 <!-- commandsstop -->
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "semver": "^7.3.7"
   },
   "devDependencies": {
-    "@adobe/eslint-config-aio-lib-config": "^2.0.1",
+    "@adobe/eslint-config-aio-lib-config": "^3.0.0",
     "acorn": "^8.7.0",
     "dedent": "^1.5.1",
     "eslint": "^8.47.0",
@@ -34,8 +34,7 @@
     "jest-junit": "^16.0.0",
     "jest-resolve": "^27.5.1",
     "oclif": "^3.2.0",
-    "stdout-stderr": "^0.1.13",
-    "typescript": "^5.1.6"
+    "stdout-stderr": "^0.1.13"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
closes #83 

## How Has This Been Tested?

1. rm -rf node_modules
2. npm i
3. npm test
4. npm run prepack
5. Inspect README.md for `See code:` links (should point to the `.js` file)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
